### PR TITLE
fixing wrong cknowledge urls (from cknowledge.ddns.net -> cknowledge.org)

### DIFF
--- a/projects/collective_knowledge.md
+++ b/projects/collective_knowledge.md
@@ -24,9 +24,9 @@ Anton Lokhmotov
 
 ### Links
 
-[cTuning website for Collective Knowledge](http://cknowledge.ddns.net/)
+[cTuning website for Collective Knowledge](http://cknowledge.org/)
 
-[Demo "Interactive Paper" for CK Browser](http://cknowledge.ddns.net/repo/web.php?wcid=report:b0779e2a64c22907)
+[Demo "Interactive Paper" for CK Browser](http://cknowledge.org/repo/web.php?wcid=report:b0779e2a64c22907)
 
 [Source Code](https://github.com/ctuning/ck)
 
@@ -84,7 +84,7 @@ Anton Lokhmotov
 
 ## Motivation
 
-From their own page at [http://cknowledge.ddns.net/](http://cknowledge.ddns.net/):
+From their own page at [http://github.com/ctuning/ck](http://github.com/ctuning/ck):
 
 > We have developed Collective Knowledge framework and repository (CK) to help researchers quickly prototype their research ideas, crowdsource experiments and reproduce results using shared CK modules with unified JSON API, while simplifying predictive analytics and knowledge exchange. For example, CK already helped computer systems' researchers (and ourselves):
 >

--- a/rubric.md
+++ b/rubric.md
@@ -34,7 +34,7 @@ title: Reproducibility Rubric
 | ----------------------------- | --- | --- | --- | --- | --- | --- | ------- | ---- | ------------ | ---- |
 | [DataMill][datamill]          | ✔ | ✗ | ✗ | ✔ | ✗ | ✗ | AGPLv3       | 2013       | University of Waterloo        | [Link](https://datamill.uwaterloo.ca/)   |
 | [Occam][occam]                | ✗ | ✔ | ✔ | ✔ | ✔ | ✔ | AGPLv3       | 2014       | University of Pittsburgh      | [Link](https://occam.cs.pitt.edu/)       |
-| [Collective Knowledge][ck]    | ✗ | ✗ | ✔ | ✗ | ✔ | ✔ | 3c-BSD       | 2014       | cTuning Foundation            | [Link](http://cknowledge.ddns.net/)      |
+| [Collective Knowledge][ck]    | ✗ | ✗ | ✔ | ✗ | ✔ | ✔ | 3c-BSD       | 2014       | cTuning Foundation            | [Link](http://cknowledge.org/)           |
 | [RunMyCode][rmc]              | ✗ | ✗ | ✔ | ✔ | ✗ | ✗ | Closed       | 2013       | RunMyCode Association         | [Link](http://runmycode.org/)            |
 | [Dataverse][dv]               | ✗ | ✗ | ✔ | ✔ | ✗ | ✗ | Apache 2.0   | 2012       | Harvard University            | [Link](https://dataverse.harvard.edu/)   |
 | [Open Science Framework][osf] | ✗ | ✗ | ✔ | ✔ | ✗ | ✗ | Apache 2.0   | 2013       | Center for Open Science       | [Link](https://osf.io/)                  |


### PR DESCRIPTION
Hi @wilkie . I noticed that cKnowledge URLs are wrong (cknowledge.ddns.net was a temporal hosting). I fixed them and provided the correct ones (cKnowledge.org). Hence this pull request ;) !...
Thanks a lot!
